### PR TITLE
fix: increase gitlab webservice mem limit to recommended min

### DIFF
--- a/bundles/dev/uds-bundle.yaml
+++ b/bundles/dev/uds-bundle.yaml
@@ -156,7 +156,7 @@ packages:
               path: "gitlab.webservice.resources"
               default:
                 limits:
-                  memory: 2.5G
+                  memory: 3.5G
                 requests:
                   cpu: 300m
                   memory: 2.5G

--- a/bundles/k3d-demo/uds-bundle.yaml
+++ b/bundles/k3d-demo/uds-bundle.yaml
@@ -178,7 +178,7 @@ packages:
               path: "gitlab.webservice.resources"
               default:
                 limits:
-                  memory: 2.5G
+                  memory: 3.5G
                 requests:
                   cpu: 300m
                   memory: 2.5G


### PR DESCRIPTION
## Description

When using the dev bundle locally, observed consistent OOMKilled crashes of the webservice pod with current 2.5G memory limit, which is below the gitlab recommended minimum: https://docs.gitlab.com/charts/charts/gitlab/webservice/#memory-requestslimits

Increase limit to 3.5G to align with gitlab recommendations, but leave requests unchanged.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-software-factory/blob/main/CONTRIBUTING.md#developer-workflow) followed
